### PR TITLE
Attn : Dylan :: SDK AMD Module Names : 25 August 2015

### DIFF
--- a/test/sdk/index.js
+++ b/test/sdk/index.js
@@ -5,9 +5,9 @@
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define([
-            'object-assign',
+            'es6-object-assign',
             'hawk',
-            'renameKeys',
+            'rename-keys',
             './authentication',
             './scans'
         ], function(


### PR DESCRIPTION
This makes the AMD names match the npm module names, causing the setup to be easier. (This is mostly for easier logon widget building.)
