### PR TITLE
handle null password case

### DIFF
--- a/lib/utils/authentication.js
+++ b/lib/utils/authentication.js
@@ -137,9 +137,18 @@ module.exports.register = function(server, options, next) {
          */
         const comparePassword = (user) => {
 
+            const rawPass = user.get('passwordHash');
+            let msg;
+
+            // validate that rawPass is not falsy
+            if (!rawPass) {
+                msg = 'Empty pwd hash for ' + user.get('username');
+                server.log(['info', 'validate-user'], msg);
+                return Bluebird.resolve(false);
+            }
+
             // php formats hashes with the $2y$ vs node's $2a$
             // this corrects them: the hashes are the same otherwise
-            const rawPass = user.get('passwordHash');
             const correctedPass = rawPass.replace(/^\$2y\$/i, '\$2a$');
             return bcryptCompare(password, correctedPass);
         };


### PR DESCRIPTION
# Asana

https://app.asana.com/0/8456484948067/52893083848647
# Background

The COINS3.0 API authenticates users by performing a bcrypt compare of a password hash stored in the database to a plain text password provided by the user. In order to handle the hash from the database using both PHP and Node, the hash needs to go through a correction in node:

> // php formats hashes with the $2y$ vs node's $2a$
>   // this corrects them: the hashes are the same otherwise
# Problem

This correction involves a string replacement, which will throw a fatal error if the stored password hash is `null`.
# Solution

Explicitly handle the `null` password case. 
