### PR TITLE
add proxy IP-Address tools and test

### DIFF
--- a/lib/app-routes/common/auth/keys.js
+++ b/lib/app-routes/common/auth/keys.js
@@ -4,6 +4,8 @@ const boom = require('boom');
 const config = require('config');
 const casCookieUtils = require('../../../utils/cas-cookie-utils.js');
 const joi = require('joi');
+const _ = require('lodash');
+const proxy = require('../../../utils/proxy.js');
 
 const baseUrl = '/keys';
 
@@ -53,7 +55,7 @@ exports.register = function(server, options, next) {
                 const data = request.payload;
                 const username = data.username.toString();
                 const password = data.password.toString();
-                
+
                 const  recordObj = {};
 
                 /**
@@ -61,7 +63,7 @@ exports.register = function(server, options, next) {
                  */
                 recordObj.username = data.username.toString();
                 recordObj.loginTime = new Date();
-                recordObj.ipAddr = data.ipAddress.toString();
+                recordObj.ipAddr = proxy.getIpAddress(request);
                 recordObj.errorCode = 0;
                 recordObj.success = 1;
 

--- a/lib/utils/proxy.js
+++ b/lib/utils/proxy.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * get the IP address from a request that might be proxied
+ * @param  {object} request a hapi request object
+ * @return {string}         the client IP address
+ */
+function getIpAddress(request) {
+    const remoteAddress = request.info.remoteAddress;
+    const forwardedFor = request.headers['x-forwarded-for'];
+
+    // get left-most IP if forwardedFor is defined
+    if (forwardedFor) {
+        return forwardedFor.split(',').unshift().trim();
+    }
+
+    return remoteAddress;
+}
+
+module.exports.getIpAddress = getIpAddress;

--- a/test/utils/init-api-client.js
+++ b/test/utils/init-api-client.js
@@ -31,6 +31,9 @@ const onPreFormatRequestOptions = (request) => {
         }
     }
 
+    //Add fake remote IP address
+    request.remoteAddress = 'mochatest';
+
     return request;
 };
 


### PR DESCRIPTION
# Background

When a user attempts to login, we should record their IP address. Requests may be coming directly from the user/client, or they may be proxied by another server. Consequently, we need to be careful about which IP address we record.
# Discussion

This Pull Request adds a simple utility for retrieving the IP address from a request. It gives preference to the left-most `x-forwarded-for` IP, and falls back to the `remoteAddress`. 

The utility is used to get the correct IP in keys.js.

Additionally, I have corrected a bug wherein the `lodash` (`_`) module was not required in this file.
