### PR TITLE
use mcrypt 0.0.15 per package author: tinyurl.com/nlmaae5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jsonwebtoken": "5.0.5",
     "knex": "0.8.6",
     "lodash": "3.10.1",
-    "mcrypt": "0.1.3",
+    "mcrypt": "0.0.15",
     "moment": "2.10.6",
     "nomnom": "1.8.1",
     "numeric": "1.2.6",


### PR DESCRIPTION
# problem statement

mcrypt fails on install, constantly.
# solution

use a version of it that the package author recommends.  confirmed successful install
# tests

they pass.

<img width="179" alt="screen shot 2015-10-08 at 2 34 46 pm" src="https://cloud.githubusercontent.com/assets/1003261/10380622/be5d7622-6dc9-11e5-8cad-fedf945afa73.png">
