### PR TITLE
change joi schema for null admin values

### DIFF
--- a/src/lib/controllers/users.js
+++ b/src/lib/controllers/users.js
@@ -14,7 +14,7 @@ internals.userSchema = joi.object().keys({
     activeFlag: joi.string().required(),
     passwordExpDate: joi.date().required(),
     acctExpDate: joi.date().required(),
-    isSiteAdmin: joi.string().required(),
+    isSiteAdmin: joi.any(),
     emailUnsubscribed: joi.boolean().required()
 });
 


### PR DESCRIPTION
The User joi schema barks on null site admin, relax restrictions
