### PR TITLE
feature/auto-add-x-forwarded-host

### DIFF
--- a/src/lib/utils/add-proxy-host-header.js
+++ b/src/lib/utils/add-proxy-host-header.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * sniffs for x-forwarded-host header.  if head found missing, fills it with
+ * host header. this app, in practice, exists behind a reverse proxy, and
+ * checks for the x-forwarded-host header to validate client mac addresses
+ * against.
+ */
+module.exports.register = function(server, options, next) {
+    server.ext('onPreAuth', (request, reply) => {
+        if (!request.headers['x-forwarded-host']) {
+            request.headers['x-forwarded-host'] = request.headers.host;
+        }
+        reply.continue();
+    });
+    next();
+};
+
+module.exports.register.attributes = {
+    name: 'add-proxy-host-header'
+};

--- a/src/lib/utils/get-plugins.js
+++ b/src/lib/utils/get-plugins.js
@@ -69,6 +69,9 @@ var plugins = [
         }
     },
     {
+        register: require('./add-proxy-host-header.js'),
+    },
+    {
         register: require('./response-formatter.js'),
         options: {
             excludeVarieties: ['view', 'file'],

--- a/src/test/utils/init-api-client.js
+++ b/src/test/utils/init-api-client.js
@@ -12,9 +12,6 @@ const formatResponseCallback = (response) => {
 
 const formatRequestHeaders = (headers) => {
     headers = headers || [];
-
-    // HAWK auth relies on x-forwarded-host headers...
-    headers.push({name: 'x-forwarded-host', value:'localhost:8800' });
     return headers.reduce((target, header) => {
         target[header.name] = header.value;
         return target;


### PR DESCRIPTION
#### asana

https://app.asana.com/0/22730822790060/86041838112584
# problem

i cant logout when running local nodeapi instance
# solution

assert hawk required headers present no matter what!
